### PR TITLE
witmotion_ros-release: 1.2.27-1 in 'noetic/distribution.yaml' [fixed duplicated entry]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -12066,19 +12066,7 @@ repositories:
       type: git
       url: https://github.com/ElettraSciComp/witmotion_IMU_ros.git
       version: main
-    source:
-      type: git
-      url: https://github.com/ElettraSciComp/witmotion_IMU_ros.git
-      version: main
-    status: maintained
-  witmotion_ros-release:
-    doc:
-      type: git
-      url: https://github.com/ElettraSciComp/witmotion_IMU_ros.git
-      version: main
     release:
-      packages:
-      - witmotion_ros
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/twdragon/witmotion_ros-release.git


### PR DESCRIPTION
Updated `distribution.yaml` for `witmotion_ros` after wrong bloom release

## Package name

witmotion_ros

## Package Upstream Source:

https://github.com/ElettraSciComp/witmotion_IMU_ros

NOETIC

# Checks
 - [ x ] All packages have a declared license in the package.xml
 - [ x ] This repository has a LICENSE file
 - [ x ] This package is expected to build on the submitted rosdistro